### PR TITLE
Patch: Fixed Flutter Web crash for 64-bit encoded types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.8
+
+### Patch: Fixed Flutter Web crash for 64-bit encoded types
+
+Bumped `prf` dependency to `^2.4.2` to resolve a Flutter Web runtime crash related to 64-bit integer encoding (`DateTime`, `List<DateTime>`, `List<Duration>`).
+No functional changes in this package.
+
 ## 1.0.7
 
 - Fixed fomatting issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: limit
 description: "Persistent across sessions, no manual storage needed. Easily manage cooldowns and rate limits with one-line."
-version: 1.0.7
+version: 1.0.8
 homepage: https://github.com/jozzzzep/limit
 repository: https://github.com/jozzzzep/limit
 issue_tracker: https://github.com/jozzzzep/limit/issues
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  prf: ^2.3.1
+  prf: ^2.4.2
   synchronized: ^3.3.1
 
 dev_dependencies:


### PR DESCRIPTION
Bumped `prf` dependency to `^2.4.2` to resolve a Flutter Web runtime crash related to 64-bit integer encoding (`DateTime`, `List<DateTime>`, `List<Duration>`). No functional changes in this package.